### PR TITLE
accept CLI arguments

### DIFF
--- a/nicolive_dl/__main__.py
+++ b/nicolive_dl/__main__.py
@@ -1,22 +1,35 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import argparse
 import asyncio
 from getpass import getpass
-import argparse
 
 from . import NicoLiveDL
 
-async def _main(username, password, live_id):
+
+async def _main(username, password, live_id, otp_required):
     nldl = NicoLiveDL()
-    nldl.login(username, password)
+    nldl.login(username, password, otp_required)
     await nldl.download(live_id)
 
-def main():
-    username = input('Account: ')
-    password = getpass('Password: ')
-    live_id = input('Live Id: ')
-    asyncio.run(_main(username, password, live_id))
 
-if __name__ == '__main__':
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-u", "--username")
+    parser.add_argument("-p", "--password")
+    parser.add_argument("-l", "--live-id")
+    parser.add_argument("--otp-required", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    username = args.username or input("Account: ")
+    password = args.password or getpass("Password: ")
+    live_id = args.live_id or input("Live Id: ")
+    asyncio.run(_main(username, password, live_id, otp_required=args.otp_required))
+
+
+if __name__ == "__main__":
     main()

--- a/nicolive_dl/__main__.py
+++ b/nicolive_dl/__main__.py
@@ -8,10 +8,10 @@ from getpass import getpass
 from . import NicoLiveDL
 
 
-async def _main(username, password, live_id, otp_required):
+async def _main(username, password, live_id, otp_required, save_comments):
     nldl = NicoLiveDL()
     nldl.login(username, password, otp_required)
-    await nldl.download(live_id)
+    await nldl.download(live_id, save_comments=save_comments)
 
 
 def parse_args():
@@ -20,6 +20,7 @@ def parse_args():
     parser.add_argument("-p", "--password")
     parser.add_argument("-l", "--live-id")
     parser.add_argument("--otp-required", action="store_true")
+    parser.add_argument("--save-comments", action="store_true")
     return parser.parse_args()
 
 
@@ -28,7 +29,15 @@ def main():
     username = args.username or input("Account: ")
     password = args.password or getpass("Password: ")
     live_id = args.live_id or input("Live Id: ")
-    asyncio.run(_main(username, password, live_id, otp_required=args.otp_required))
+    asyncio.run(
+        _main(
+            username,
+            password,
+            live_id,
+            otp_required=args.otp_required,
+            save_comments=args.save_comments,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/nicolive_dl/__main__.py
+++ b/nicolive_dl/__main__.py
@@ -16,11 +16,23 @@ async def _main(username, password, live_id, otp_required, save_comments):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-u", "--username")
-    parser.add_argument("-p", "--password")
-    parser.add_argument("-l", "--live-id")
-    parser.add_argument("--otp-required", action="store_true")
-    parser.add_argument("--save-comments", action="store_true")
+    parser.add_argument("-u", "--username", help="Username/Email address")
+    parser.add_argument("-p", "--password", help="Password")
+    parser.add_argument(
+        "-l",
+        "--live-id",
+        help="Live ID. lv0123456789 if the Live URL is https://live.nicovideo.jp/watch/lv0123456789",
+    )
+    parser.add_argument(
+        "--otp-required",
+        action="store_true",
+        help="Whether an OTP is required to login (2FA enabled)",
+    )
+    parser.add_argument(
+        "--save-comments",
+        action="store_true",
+        help="Whether to save comments. Comments will be saved in the same directory as the video",
+    )
     return parser.parse_args()
 
 

--- a/nicolive_dl/nicolive_dl.py
+++ b/nicolive_dl/nicolive_dl.py
@@ -1,50 +1,56 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import json
 import asyncio
-from enum import Enum
+import json
+from collections import namedtuple
 from pathlib import Path
 from urllib.parse import unquote
-from collections import namedtuple
-from requests import Session
+
 from bs4 import BeautifulSoup, Tag
+from requests import Session
 from sanitize_filename import sanitize
-from .nicolive_ws import NicoLiveWS, NicoLiveCommentWS
+
 from .exceptions import *
+from .nicolive_ws import NicoLiveCommentWS, NicoLiveWS
 
-
-NicoLiveInfo = namedtuple('NicoLiveInfo', 'lvid title web_socket_url')
+NicoLiveInfo = namedtuple("NicoLiveInfo", "lvid title web_socket_url")
 
 
 class NicoLiveDL:
     def __init__(self):
         self.ses = Session()
 
-    def login(self, username, password):
-        payload = {'mail_tel': username, 'password': password}
-        login_url = 'https://account.nicovideo.jp/login/redirector'
+    def login(self, username, password, otp_required=False):
+        payload = {"mail_tel": username, "password": password}
+        login_url = "https://account.nicovideo.jp/login/redirector"
         res = self.ses.post(login_url, data=payload)
-        #check email for otp
-        otp = input('OTP: ')
-        payload2 = {'otp': otp, 'loginBtn': 'Login', 'is_mfa_trusted_device': 'true', 'device_name': 'nicolivedl'}
-        otp_url = res.url
-        res2 = self.ses.post(otp_url, data=payload2)
-        if res2.url != 'https://account.nicovideo.jp/my/account':
-            raise LoginError('Failed to Login')
+        # check email for otp
+        if otp_required:
+            otp = input("OTP: ")
+            payload2 = {
+                "otp": otp,
+                "loginBtn": "Login",
+                "is_mfa_trusted_device": "true",
+                "device_name": "nicolivedl",
+            }
+            otp_url = res.url
+            res2 = self.ses.post(otp_url, data=payload2)
+            if res2.url != "https://account.nicovideo.jp/my/account":
+                raise LoginError("Failed to Login")
 
-    async def download(self, lvid, output='{title}-{lvid}.ts'):
+    async def download(self, lvid, output="{title}-{lvid}.ts"):
         lvid, title, web_socket_url = await self.get_info(lvid)
         title = sanitize(title)
         output_path = Path(output.format(title=title, lvid=lvid))
-        comment_output_path = output_path.parent / (output_path.stem + '.jsonl')
+        comment_output_path = output_path.parent / (output_path.stem + ".jsonl")
 
         if output_path.exists():
             while True:
-                ans = input(f'Can you overwrite {output_path}? [y/n]')
-                if ans.lower() == 'y':
+                ans = input(f"Can you overwrite {output_path}? [y/n]")
+                if ans.lower() == "y":
                     break
-                elif ans.lower() == 'n':
+                elif ans.lower() == "n":
                     return
         nlws = NicoLiveWS(web_socket_url)
         asyncio.create_task(nlws.connect())
@@ -53,20 +59,20 @@ class NicoLiveDL:
         asyncio.create_task(comment_ws.connect())
         stream_uri = await nlws.wait_for_stream()
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        args = ['-y', '-i', stream_uri, '-c', 'copy', output_path]
-        proc = await asyncio.create_subprocess_exec('ffmpeg', *args)
+        args = ["-y", "-i", stream_uri, "-c", "copy", output_path]
+        proc = await asyncio.create_subprocess_exec("ffmpeg", *args)
         await proc.communicate()
         await nlws.close()
 
     async def get_info(self, lvid):
-        res = self.ses.get(f'https://live.nicovideo.jp/watch/{lvid}')
+        res = self.ses.get(f"https://live.nicovideo.jp/watch/{lvid}")
         res.raise_for_status()
-        soup = BeautifulSoup(res.content, 'html.parser')
-        embedded_tag = soup.select_one('#embedded-data')
+        soup = BeautifulSoup(res.content, "html.parser")
+        embedded_tag = soup.select_one("#embedded-data")
         if not isinstance(embedded_tag, Tag):
-            raise SelectException('Not Found #embedded-data')
-        embedded_data = embedded_tag.get_attribute_list('data-props')[0]
+            raise SelectException("Not Found #embedded-data")
+        embedded_data = embedded_tag.get_attribute_list("data-props")[0]
         decoded_data = json.loads(unquote(embedded_data))
-        web_socket_url = decoded_data['site']['relive']['webSocketUrl']
-        title = decoded_data['program']['title']
+        web_socket_url = decoded_data["site"]["relive"]["webSocketUrl"]
+        title = decoded_data["program"]["title"]
         return NicoLiveInfo(lvid, title, web_socket_url)


### PR DESCRIPTION
Improvement:
* Parse CLI args for `username`, `password` and `live-id`. Still ask user inputs when a required param is not passed via CLI
* Parse CLI arg for `otp-required`, will only ask the user input when `--otp-required` is given. The motivation is: not everyone has 2FA enabled.
* Parse CLI arg for `save-comments` since it's an optional feature.

```bash
~ nicolive_dl -h
usage: nicolive_dl [-h] [-u USERNAME] [-p PASSWORD] [-l LIVE_ID] [--otp-required] [--save-comments]

optional arguments:
  -h, --help            show this help message and exit
  -u USERNAME, --username USERNAME
                        Username/Email address
  -p PASSWORD, --password PASSWORD
                        Password
  -l LIVE_ID, --live-id LIVE_ID
                        Live ID. lv0123456789 if the Live URL is https://live.nicovideo.jp/watch/lv0123456789
  --otp-required        Whether an OTP is required to login (2FA enabled)
  --save-comments       Whether to save comments. Comments will be saved in the same directory as the video
```

Style changes:
* Changed files are formatted with [black](https://github.com/psf/black) and [isort](https://pycqa.github.io/isort/)

Closes #1 