### PR TITLE
Feat/allow live url as arg

### DIFF
--- a/nicolive_dl/__init__.py
+++ b/nicolive_dl/__init__.py
@@ -1,15 +1,23 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from .nicolive_dl import NicoLiveDL, NicoLiveInfo
-from .nicolive_ws import NicoLiveWS, WebSocketApp
 from .exceptions import *
+from .nicolive_dl import LIVE_URL_PREFIX, NicoLiveDL, NicoLiveInfo
+from .nicolive_ws import NicoLiveWS, WebSocketApp
 
-__copyright__    = 'Copyright (C) 2020 kairi'
-__version__      = '0.1.4'
-__license__      = 'MIT'
-__author__       = 'kairi'
-__author_email__ = 'kairi.satellite@gmail.com'
-__url__          = 'https://github.com/kairi003/nicolive-dl'
+__copyright__ = "Copyright (C) 2020 kairi"
+__version__ = "0.1.4"
+__license__ = "MIT"
+__author__ = "kairi"
+__author_email__ = "kairi.satellite@gmail.com"
+__url__ = "https://github.com/kairi003/nicolive-dl"
 
-__all__ = ['NicoLiveDL', 'NicoLiveWS', 'WebSocketApp', 'NicoLiveInfo', 'LoginError', 'SelectException']
+__all__ = [
+    "NicoLiveDL",
+    "NicoLiveWS",
+    "WebSocketApp",
+    "NicoLiveInfo",
+    "LoginError",
+    "SelectException",
+    "LIVE_URL_PREFIX",
+]

--- a/nicolive_dl/__main__.py
+++ b/nicolive_dl/__main__.py
@@ -5,7 +5,7 @@ import argparse
 import asyncio
 from getpass import getpass
 
-from . import NicoLiveDL
+from . import LIVE_URL_PREFIX, NicoLiveDL
 
 
 async def _main(username, password, live_id, otp_required, save_comments):
@@ -21,7 +21,7 @@ def parse_args():
     parser.add_argument(
         "-l",
         "--live-id",
-        help="Live ID or Live URL. Valid format of Live URL: https://live.nicovideo.jp/watch/lv0123456789, lv0123456789 is the Live ID in this case",
+        help=f"Live ID or Live URL. Valid format of Live URL: {LIVE_URL_PREFIX}lv0123456789, lv0123456789 is the Live ID in this case",
     )
     parser.add_argument(
         "--otp-required",

--- a/nicolive_dl/__main__.py
+++ b/nicolive_dl/__main__.py
@@ -21,7 +21,7 @@ def parse_args():
     parser.add_argument(
         "-l",
         "--live-id",
-        help="Live ID. lv0123456789 if the Live URL is https://live.nicovideo.jp/watch/lv0123456789",
+        help="Live ID or Live URL. Valid format of Live URL: https://live.nicovideo.jp/watch/lv0123456789, lv0123456789 is the Live ID in this case",
     )
     parser.add_argument(
         "--otp-required",

--- a/nicolive_dl/nicolive_dl.py
+++ b/nicolive_dl/nicolive_dl.py
@@ -14,6 +14,8 @@ from sanitize_filename import sanitize
 from .exceptions import *
 from .nicolive_ws import NicoLiveCommentWS, NicoLiveWS
 
+LIVE_URL_PREFIX = "https://live.nicovideo.jp/watch/"
+
 NicoLiveInfo = namedtuple("NicoLiveInfo", "lvid title web_socket_url")
 
 
@@ -40,6 +42,8 @@ class NicoLiveDL:
                 raise LoginError("Failed to Login")
 
     async def download(self, lvid, output="{title}-{lvid}.ts", save_comments=False):
+        if lvid.startswith(LIVE_URL_PREFIX):
+            lvid = lvid[len(LIVE_URL_PREFIX) :]
         lvid, title, web_socket_url = await self.get_info(lvid)
         title = sanitize(title)
         output_path = Path(output.format(title=title, lvid=lvid))
@@ -68,7 +72,7 @@ class NicoLiveDL:
         await nlws.close()
 
     async def get_info(self, lvid):
-        res = self.ses.get(f"https://live.nicovideo.jp/watch/{lvid}")
+        res = self.ses.get(f"{LIVE_URL_PREFIX}{lvid}")
         res.raise_for_status()
         soup = BeautifulSoup(res.content, "html.parser")
         embedded_tag = soup.select_one("#embedded-data")


### PR DESCRIPTION
This MR is a minor update to accept the full Live URL as an argument. 

Context: I found it's sometimes easier to copy the full URL than the Live ID. Instead of pasting the full URL and removing the extra prefix, I think it would be no harm to update `nicolive-dl` to accept both Live URL and Live ID.